### PR TITLE
SE-1705 - Chrome Issue : Group Tools - Hierarchy Tree is not showing the complete list - Blank Space appears

### DIFF
--- a/hc-nested-list.html
+++ b/hc-nested-list.html
@@ -19,12 +19,11 @@ Custom property | Description | Default
   <template>
     <style>
       :host {
-        display: block;
+        display: flex;
         padding-top: 8px;
         padding-bottom: 8px;
-        min-height: 250px;
+        height: 250px;
         flex-direction: column;
-        height: 100vh;
 
         @apply --hc-nested-list;
       }

--- a/hc-nested-list.html
+++ b/hc-nested-list.html
@@ -23,8 +23,8 @@ Custom property | Description | Default
         padding-top: 8px;
         padding-bottom: 8px;
         min-height: 250px;
-        display: flex;
         flex-direction: column;
+        height: 100vh;
 
         @apply --hc-nested-list;
       }


### PR DESCRIPTION
SE-1725:- Sets height to explicit view height due to iron-list constraints.

Please reference the following link around explicit sizing for iron-list components.
https://github.com/PolymerElements/iron-list#sizing-iron-list