### PR TITLE
SE-1705 - Chrome Issue : Group Tools - Hierarchy Tree is not showing the complete list - Blank Space appears

### DIFF
--- a/hc-nested-list.html
+++ b/hc-nested-list.html
@@ -19,11 +19,13 @@ Custom property | Description | Default
   <template>
     <style>
       :host {
-        display: flex;
+        display: block;
         padding-top: 8px;
         padding-bottom: 8px;
-        height: 250px;
+        min-height: 250px;
         flex-direction: column;
+        height: auto;
+        overflow: hidden;
 
         @apply --hc-nested-list;
       }

--- a/hc-nested-list.html
+++ b/hc-nested-list.html
@@ -19,12 +19,11 @@ Custom property | Description | Default
   <template>
     <style>
       :host {
-        display: block;
+        display: flex;
         padding-top: 8px;
         padding-bottom: 8px;
-        min-height: 250px;
+        height: 250px;
         flex-direction: column;
-        height: 100vh;
 
         @apply --hc-nested-list;
       }

--- a/hc-nested-list.html
+++ b/hc-nested-list.html
@@ -23,8 +23,8 @@ Custom property | Description | Default
         padding-top: 8px;
         padding-bottom: 8px;
         min-height: 250px;
-        display: flex;
         flex-direction: column;
+        height: 100vh;
 
         @apply --hc-nested-list;
       }


### PR DESCRIPTION
SE-1705:- Uses height auto with overflow hidden.