### PR TITLE
Add levelsCap variable to restrict number of hierarchy levels in tree

### DIFF
--- a/hc-nested-list-behavior.html
+++ b/hc-nested-list-behavior.html
@@ -57,6 +57,13 @@
         computed: '_computeItems(parts)',
         observer: '__updateList',
       },
+      /**
+       * Maximum number of hierarchy levels permitted on tree.
+       */
+      levelsCap: {
+        type: Number,
+        value: -1,
+      },
     },
     observers: [
       '_computeParts(items, itemIdName, itemParentIdName)',
@@ -186,8 +193,8 @@
       // Push all items into the new array, and if there is a child item then push all of the children.
       items.forEach((item) => {
         // Some properties need to be re-calculated every time we update the list to support lazy-loading
-        item.hasChildren = item.hasChildren || Boolean(parts[item[this.itemIdName]]);
         item.depth = !(item.depth >= 0) ? this._getItemDepth(item, parts) : item.depth;
+        item.hasChildren = this.__calculateHasChildren(item, levelsCap);
 
         newItems.push(item);
         if (item.open)
@@ -249,6 +256,20 @@
       }
 
       return depth;
+    },
+    /**
+     * Determine if node's hasChildren property is true or false based on levelsCap and item values
+     *
+     * @private
+     * @param {Object} item
+     * @param {Number} levelsCap - number of hierarchy levels to permit
+     * @return {Boolean}
+     */
+    __calculateHasChildren(item, levelsCap) {
+      if(item.depth && levelsCap && levelsCap > -1) {
+        if ((levelsCap-1) <= item.depth) return false;
+      }
+      return item.hasChildren || Boolean(parts[item[this.itemIdName]]);
     },
     /**
      * Used to fetch the parentId if it's available or default back to 'root'.

--- a/hc-tree-view.html
+++ b/hc-tree-view.html
@@ -94,7 +94,9 @@ Custom property | Description | Default
           value() {
             return Boolean(Polymer.Element);
           },
-        }
+        },
+        /* Set number if constraining number of hierarchy levels from top of tree */
+        levelsCap: Number,
       },
       ready() {
         Polymer.RenderStatus.afterNextRender(this, () => {


### PR DESCRIPTION
Intent is that one can set the maximum number of levels in the tree, preventing expansion to levels below if not desired.  (In this use case, this is to override the item's own static knowledge of if it has children in the database, regardless of if it has child nodes in the sent data set.)