### PR TITLE
Lk/fix no state change

### DIFF
--- a/hc-tree-view-behavior.html
+++ b/hc-tree-view-behavior.html
@@ -137,9 +137,9 @@
      */
     itemSelectedChanged({detail}) {
       if (detail.selected) {
-        this.selectItems([detail.item], true);
+        this.selectItems([detail.item]);
       } else {
-        this.deselectItems([detail.item], true);
+        this.deselectItems([detail.item]);
       }
       if (detail.state !== undefined && Polymer.Element) {
         this._updateState([detail.item], detail.state)
@@ -303,7 +303,7 @@
      * @param {String} [uniqueIdentifier = this.itemIdName] - Field uniquely identifying
      * each item in both sets.
      * @return {Object[]} - Return the set difference Set(items) - Set(referenceItems) or
-     * an empty array. 
+     * an empty array.
      */
     __uniqueItems(items, referenceItems = this.selectedItems, uniqueIdentifier = this.itemIdName) {
       if (!Array.isArray(items) || !Array.isArray(referenceItems)) return [];


### PR DESCRIPTION
There is an issue where the state of a clicked item is not changed.  Which selected boxes are properly reset due to the "checked" logic, deselected items are reset as still selected due to the unchanged state of "on".  The checkbox uses state to know to appear selected or not.  This results in a mismatch between the visual selected state and the selected items.
